### PR TITLE
Change libWeatherGadget.a from `None` to `Content` build action.

### DIFF
--- a/Exercise 1/Completed/BindingByHand/BindingByHand.csproj
+++ b/Exercise 1/Completed/BindingByHand/BindingByHand.csproj
@@ -100,7 +100,7 @@
   <ItemGroup>
     <None Include="Info.plist" />
     <None Include="Entitlements.plist" />
-    <None Include="libWeatherGadget.a" />
+    <Content Include="libWeatherGadget.a" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />


### PR DESCRIPTION
The None action will not copy the file to XMA agent during a Windows connected build. Content action will copy it and solve the build failure from Windows.

Second attempt at https://github.com/XamarinUniversity/IOS450/pull/1